### PR TITLE
Charts

### DIFF
--- a/TODO
+++ b/TODO
@@ -22,5 +22,4 @@ Long Term
 
 TODO: build xml file for exporting permissions to Google SDC for secure google spreadsheet importing
 TODO: Add oauth for outside report gathering/pulling
-TODO: Add support for embedded graphs and charts (maybe alternate output format that allows embedding?)
 TODO: Create emailer model that allows you to specify a certain report+filter and have it emailed daily

--- a/reportengine/base.py
+++ b/reportengine/base.py
@@ -112,7 +112,7 @@ class ModelReport(QuerySetReport):
     def get_queryset(self, filters, order_by, queryset=None):
         if queryset is None and self.queryset is None:
             queryset = self.model.objects.all()
-        return super(ModelReport).get_queryset(filters, order_by, queryset)
+        return super(ModelReport, self).get_queryset(filters, order_by, queryset)
 
 class SQLReport(Report):
     rows_sql=None # sql statement with named  parameters in python syntax (e.g. "%(age)s" )

--- a/reportengine/filtercontrols.py
+++ b/reportengine/filtercontrols.py
@@ -21,21 +21,21 @@ class FilterControl(object):
         return {self.field_name:forms.CharField(label=self.label or self.field_name,required=False)}
 
     # Pulled from django.contrib.admin.filterspecs
+    @classmethod
     def register(cls, test, factory, datatype):
         cls.filter_controls.append((test, factory, datatype))
-    register = classmethod(register)
 
+    @classmethod
     def create_from_modelfield(cls, f, field_name, label=None):
         for test, factory, datatype in cls.filter_controls:
             if test(f):
                 return factory(field_name,label)
-    create_from_modelfield = classmethod(create_from_modelfield)
 
+    @classmethod
     def create_from_datatype(cls, datatype, field_name, label=None):
         for test, factory, dt in cls.filter_controls:
             if dt == datatype:
                 return factory(field_name,label)
-    create_from_datatype = classmethod(create_from_datatype)
 
 FilterControl.register(lambda m: isinstance(m,models.CharField),FilterControl,"char")
 

--- a/reportengine/models.py
+++ b/reportengine/models.py
@@ -105,6 +105,10 @@ class ReportRequest(AbstractScheduledTask):
         self.aggregates = aggregates
         self.completion_timestamp = datetime.datetime.now()
         self.save()
+
+    def get_charts(self, output_format, data):
+        report = self.get_report()
+        return [chart_class(report.columns, data) for chart_class in report.get_charts(output_format)]
     
     def get_task_function(self):
         from tasks import async_report
@@ -114,6 +118,11 @@ class ReportRequestRow(models.Model):
     report_request = models.ForeignKey(ReportRequest, related_name='rows')
     row_number = models.PositiveIntegerField()
     data = JSONField(datatype=list)
+
+    def __iter__(self):
+        return iter(self.data)
+    def __getitem__(self, key):
+        return self.data[key]
 
 class ReportRequestExport(AbstractScheduledTask):
     report_request = models.ForeignKey(ReportRequest, related_name='exports')

--- a/reportengine/outputformats.py
+++ b/reportengine/outputformats.py
@@ -28,6 +28,10 @@ class OutputFormat(object):
     def get_response(self,context,request):
         raise NotImplemented("Use a subclass of OutputFormat.")
 
+    def can_embed(self, chart):
+        # You will probably want to employ duck typing here.
+        return False
+
 class AdminOutputFormat(OutputFormat):
     verbose_name="Admin Report"
     slug="admin"
@@ -39,6 +43,10 @@ class AdminOutputFormat(OutputFormat):
         context.update({"output_format":self})
         return render_to_response('reportengine/report.html', context,
                               context_instance=RequestContext(request))
+
+    def can_embed(self, chart):
+        # Actually, initalize_html is also used in template but we don't consider it as required attribute.
+        return hasattr(chart, 'render_html')
 
 class CSVOutputFormat(OutputFormat):
     verbose_name="CSV (comma separated value)"

--- a/reportengine/templates/reportengine/report.html
+++ b/reportengine/templates/reportengine/report.html
@@ -11,6 +11,9 @@
     <script type="text/javascript" src="{% admin_media_prefix %}js/core.js"></script>
     <script type="text/javascript" src="{% admin_media_prefix %}js/calendar.js"></script>
     <script type="text/javascript" src="{% admin_media_prefix %}js/admin/DateTimeShortcuts.js"></script>
+    {% for chart in charts %}
+    {{ chart.initialize_html }}
+    {% endfor %}
 {% endblock %}
 
 {% block bodyclass %}change-list{% endblock %}
@@ -62,6 +65,10 @@
         {% endfor %}
     </div>
     {% endblock %}
+
+{% for chart in charts %}
+    {{ chart.render_html }}
+{% endfor %}
 
 <h3>Data</h3>
  <table>


### PR DESCRIPTION
I've added chart support. It is written in a way that tries to be backend agnostic, so a user is not forced to use any particular packages. Instead the only thing reportengine demands from user is to provide callables that accept particular format of parameters and return objects suitable for rendering in selected output format(s) (which will usually mean duck typing). That way we are not tied to any specific chart backend and it should be quite easy to write wrappers for existing backends.

Chart configuration format probably needs rethinking; I'm not sure if it shouldn't be a bit simpler.

I've also made a Google Chart API wrapper (for new version of API released in April 2012) which is suitable for use with this set of commits: https://github.com/KrzysiekJ/gchart
