### PR TITLE
Fix template tag deprecation issues for Django 1.8

### DIFF
--- a/reportengine/templates/reportengine/async_wait.html
+++ b/reportengine/templates/reportengine/async_wait.html
@@ -19,7 +19,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
      <a href="/admin/">{% trans "Home" %}</a> &rsaquo;
-     <a href="{% url reports-list %}">{% trans "Reports" %}</a> &rsaquo;
+     <a href="{% url 'reports-list' %}">{% trans "Reports" %}</a> &rsaquo;
      <a href="{{ report_request.get_report_url }}">{{report.verbose_name}}</a> &rsaquo;
      {% if format %}
      <a href="{{ report_request.get_absolute_url }}">{% trans "Report Result" %}</a> &rsaquo;

--- a/reportengine/templates/reportengine/calendar.html
+++ b/reportengine/templates/reportengine/calendar.html
@@ -1,8 +1,8 @@
 {% extends "admin/base_site.html" %}
-{% load adminmedia admin_list i18n %}
+{% load static admin_list i18n %}
 
 {% block extrastyle %}
-  <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/changelists.css" />
+  <link rel="stylesheet" type="text/css" href="{% static 'css/changelists.css' %}" />
 {% endblock %}
 
 {% block bodyclass %}change-list{% endblock %}
@@ -10,7 +10,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
      <a href="/admin/">{% trans "Home" %}</a> &rsaquo;
-     <a href="{% url reports-list %}">Reports</a> &rsaquo;
+     <a href="{% url 'reports-list' %}">Reports</a> &rsaquo;
      calendar for {% block calendar_breadcrumb %}{% endblock %}
 </div>
 {% endblock %}

--- a/reportengine/templates/reportengine/calendar_day.html
+++ b/reportengine/templates/reportengine/calendar_day.html
@@ -7,7 +7,7 @@
 
     <ul>
     {% for r in reports %}
-    <li><a href="{% url reports-date-range date.year date.month date.day r.namespace r.slug %}">{{ r.verbose_name }}</a></li>
+    <li><a href="{% url 'reports-date-range' date.year date.month date.day r.namespace r.slug %}">{{ r.verbose_name }}</a></li>
     {% endfor %}
     </ul>
 

--- a/reportengine/templates/reportengine/calendar_month.html
+++ b/reportengine/templates/reportengine/calendar_month.html
@@ -5,13 +5,13 @@
 {% block calendarcontent %}
     <h2>Reports for {{ date|date:"M Y" }}</h2>
 
-    <a href="{% url reports-calendar-current %}">current month</a>
+    <a href="{% url 'reports-calendar-current' %}">current month</a>
     <!-- TODO: make this localized -->
     <table>
         <tr>
-            <td><a href="{% url reports-calendar-month prev.year prev.month %}">&laquo;</a></td>
+            <td><a href="{% url 'reports-calendar-month' prev.year prev.month %}">&laquo;</a></td>
             <td colspan="5"></td>
-            <td><a href="{% url reports-calendar-month next.year next.month %}">&raquo;</a></td>
+            <td><a href="{% url 'reports-calendar-month' next.year next.month %}">&raquo;</a></td>
         </tr>
         <tr>
             <td>M</td>
@@ -28,7 +28,7 @@
         <td>
             {% if day %}
                 <div class="day">
-                   <a href="{% url reports-calendar-day date.year date.month date.day %}">{{ day }}</a>
+                   <a href="{% url 'reports-calendar-day' date.year date.month date.day %}">{{ day }}</a>
                 </div>
             {% endif %}
         </td>

--- a/reportengine/templates/reportengine/list.html
+++ b/reportengine/templates/reportengine/list.html
@@ -1,8 +1,8 @@
 {% extends "admin/base_site.html" %}
-{% load adminmedia admin_list i18n %}
+{% load static admin_list i18n %}
 
 {% block extrastyle %}
-  <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/changelists.css" />
+  <link rel="stylesheet" type="text/css" href="{% static 'css/changelists.css' %}" />
 {% endblock %}
 
 
@@ -28,7 +28,7 @@
 		<H2>Reports</H2>
 
     <div>
-        <a href="{% url reports-calendar-current %}">Calendar View</a>
+        <a href="{% url 'reports-calendar-current' %}">Calendar View</a>
     </div>
 
       <div id="changelist">
@@ -36,7 +36,7 @@
             {% for namespace in report_list %}
                 <h3>{{ namespace.grouper|title }}</h3>
                 {% for report in namespace.list|dictsort:"verbose_name" %}
-                    <a href="{% url reports-view report.namespace report.slug %}">{{ report.verbose_name }}</a><br />
+                    <a href="{% url 'reports-view' report.namespace report.slug %}">{{ report.verbose_name }}</a><br />
                 {% endfor %}
             {% endfor %}
 	  </div>

--- a/reportengine/templates/reportengine/report.html
+++ b/reportengine/templates/reportengine/report.html
@@ -1,16 +1,16 @@
 {% extends "admin/base_site.html" %}
-{% load adminmedia admin_list i18n %}
+{% load static admin_list i18n %}
 
 {% block extrastyle %}
-    <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />
-    <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/changelists.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/forms.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/changelists.css' %}" />
 {% endblock %}
 
 {% block extrahead %}
-    <script type="text/javascript" src="{% url admin:jsi18n %}"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/core.js"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/calendar.js"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/admin/DateTimeShortcuts.js"></script>
+    <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+    <script type="text/javascript" src="{% static 'js/core.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/calendar.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/admin/DateTimeShortcuts.js' %}"></script>
 {% endblock %}
 
 {% block bodyclass %}change-list{% endblock %}
@@ -18,7 +18,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
      <a href="/admin/">{% trans "Home" %}</a> &rsaquo;
-     <a href="{% url reports-list %}">{% trans "Reports" %}</a> &rsaquo;
+     <a href="{% url 'reports-list' %}">{% trans "Reports" %}</a> &rsaquo;
      <a href="{{ report_request.get_report_url }}">{{report.verbose_name}}</a> &rsaquo;
      {% trans "Report Result" %}
 </div>
@@ -57,7 +57,7 @@
         {% ifequal of output_format %}
         {{ of.verbose_name }} {% if not forloop.last %}|{% endif %}
         {% else %}
-        <a href="{% url reports-request-view-format report_request.token of.slug %}">{{ of.verbose_name }}</a> {% if not forloop.last %}|{% endif %}
+        <a href="{% url 'reports-request-view-format' report_request.token of.slug %}">{{ of.verbose_name }}</a> {% if not forloop.last %}|{% endif %}
         {% endifequal %}
         {% endfor %}
     </div>

--- a/reportengine/templates/reportengine/request_report.html
+++ b/reportengine/templates/reportengine/request_report.html
@@ -1,17 +1,17 @@
 {% extends "admin/base_site.html" %}
-{% load adminmedia admin_list i18n %}
+{% load static admin_list i18n %}
 
 {% block extrastyle %}
-    <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />
-    <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/changelists.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/forms.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/changelists.css' %}" />
 {% endblock %}
 
 {% block extrahead %}
-    <script type="text/javascript" src="{% url admin:jsi18n %}"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/jquery.init.js"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/core.js"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/calendar.js"></script>
-    <script type="text/javascript" src="{% admin_media_prefix %}js/admin/DateTimeShortcuts.js"></script>
+    <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+    <script type="text/javascript" src="{% static 'js/jquery.init.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/core.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/calendar.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/admin/DateTimeShortcuts.js' %}"></script>
 {% endblock %}
 
 {% block bodyclass %}change-list{% endblock %}
@@ -19,7 +19,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
      <a href="/admin/">{% trans "Home" %}</a> &rsaquo;
-     <a href="{% url reports-list %}">{% trans "Reports" %}</a> &rsaquo;
+     <a href="{% url 'reports-list' %}">{% trans "Reports" %}</a> &rsaquo;
      {{report.verbose_name}}
 </div>
 {% endblock %}


### PR DESCRIPTION
I think these were just warnings in 1.7 but they error in 1.8. Should work fine back to 1.6.
